### PR TITLE
Fixes for Install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,13 @@
 swift build --configuration release
 
 LOCAL=/usr/local
-BIN={$LOCAL}/bin
+BIN=${LOCAL}/bin
 TOOL_DIR=${LOCAL}/EnvelopeTool
 TOOL=${BIN}/envelope
-BUILD={$PWD}/.build/release
+BUILD=${PWD}/.build/release
 
 sudo rm -rf ${TOOL_DIR}
-sudo mkdir -f ${TOOL_DIR}
+sudo mkdir ${TOOL_DIR}
 sudo cp -f ${BUILD}/EnvelopeTool ${TOOL_DIR}/
 sudo cp -Rf ${BUILD}/BCWally.framework ${TOOL_DIR}/
 sudo cp -Rf ${BUILD}/SSKR.framework ${TOOL_DIR}/


### PR DESCRIPTION
Made some corrections to install.sh. I would suggest using this instead of the link.sh currently suggested in the Docs, because that leaves the binary wherever you built it, where this more correctly installs it in /usr/local.

(Not sure the ramifications/use of also installing those frameworks.)